### PR TITLE
Add SalaryData Xcode project to salary analysis repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# macOS
+.DS_Store
+
+# LaTeX build artifacts
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.loc
+*.log
+*.out
+*.run.xml
+*.soc
+
+# Project output
+main.pdf
+
+# Xcode / SwiftPM user-specific files
+DerivedData/
+build/
+*.xcuserstate
+*.xcscmblueprint
+*.xccheckout
+xcuserdata/

--- a/SalaryData.xcodeproj/project.pbxproj
+++ b/SalaryData.xcodeproj/project.pbxproj
@@ -1,0 +1,324 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3874E4BD2D0B372300D8C9AB /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 3874E4BC2D0B372300D8C9AB /* SwiftSoup */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3874E4A92D0B36C100D8C9AB /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		3874E4AB2D0B36C100D8C9AB /* SalaryData */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SalaryData; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		3874E4AD2D0B36C100D8C9AB /* SalaryData */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SalaryData;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3874E4A82D0B36C100D8C9AB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3874E4BD2D0B372300D8C9AB /* SwiftSoup in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3874E4A22D0B36C100D8C9AB = {
+			isa = PBXGroup;
+			children = (
+				3874E4AD2D0B36C100D8C9AB /* SalaryData */,
+				3874E4AC2D0B36C100D8C9AB /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3874E4AC2D0B36C100D8C9AB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3874E4AB2D0B36C100D8C9AB /* SalaryData */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3874E4AA2D0B36C100D8C9AB /* SalaryData */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3874E4B22D0B36C100D8C9AB /* Build configuration list for PBXNativeTarget "SalaryData" */;
+			buildPhases = (
+				3874E4A72D0B36C100D8C9AB /* Sources */,
+				3874E4A82D0B36C100D8C9AB /* Frameworks */,
+				3874E4A92D0B36C100D8C9AB /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3874E4AD2D0B36C100D8C9AB /* SalaryData */,
+			);
+			name = SalaryData;
+			packageProductDependencies = (
+				3874E4BC2D0B372300D8C9AB /* SwiftSoup */,
+			);
+			productName = SalaryData;
+			productReference = 3874E4AB2D0B36C100D8C9AB /* SalaryData */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3874E4A32D0B36C100D8C9AB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					3874E4AA2D0B36C100D8C9AB = {
+						CreatedOnToolsVersion = 16.2;
+					};
+				};
+			};
+			buildConfigurationList = 3874E4A62D0B36C100D8C9AB /* Build configuration list for PBXProject "SalaryData" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3874E4A22D0B36C100D8C9AB;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				3874E4BB2D0B372300D8C9AB /* XCRemoteSwiftPackageReference "SwiftSoup" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 3874E4AC2D0B36C100D8C9AB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3874E4AA2D0B36C100D8C9AB /* SalaryData */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3874E4A72D0B36C100D8C9AB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		3874E4B02D0B36C100D8C9AB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		3874E4B12D0B36C100D8C9AB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		3874E4B32D0B36C100D8C9AB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = Z242C89869;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3874E4B42D0B36C100D8C9AB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = Z242C89869;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3874E4A62D0B36C100D8C9AB /* Build configuration list for PBXProject "SalaryData" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3874E4B02D0B36C100D8C9AB /* Debug */,
+				3874E4B12D0B36C100D8C9AB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3874E4B22D0B36C100D8C9AB /* Build configuration list for PBXNativeTarget "SalaryData" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3874E4B32D0B36C100D8C9AB /* Debug */,
+				3874E4B42D0B36C100D8C9AB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		3874E4BB2D0B372300D8C9AB /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/scinfu/SwiftSoup.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.7.6;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		3874E4BC2D0B372300D8C9AB /* SwiftSoup */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3874E4BB2D0B372300D8C9AB /* XCRemoteSwiftPackageReference "SwiftSoup" */;
+			productName = SwiftSoup;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 3874E4A32D0B36C100D8C9AB /* Project object */;
+}

--- a/SalaryData.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SalaryData.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SalaryData.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SalaryData.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "2b6d335272326468abc2114223e2ce9f2cf9645d68fa4e525733ecbf43f90359",
+  "pins" : [
+    {
+      "identity" : "swiftsoup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scinfu/SwiftSoup.git",
+      "state" : {
+        "revision" : "0837db354faf9c9deb710dc597046edaadf5360f",
+        "version" : "2.7.6"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SalaryData/CohortDefinitions.swift
+++ b/SalaryData/CohortDefinitions.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct CohortDefinition {
+    let key: String
+    let label: String
+    let members: Set<String>
+}
+
+let MHIResearchersSourceURL = "https://uwaterloo.ca/public-health-sciences/our-people/health-informatics-researchers"
+
+// Optional alternative cohort for sensitivity analysis.
+// Populate using the same "SURNAME, GIVEN NAME" convention as other lists.
+let BiasConcernFacultyNames: [String] = [
+]
+
+func canonicalFacultyName(_ raw: String) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    return trimmed.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+}
+
+func canonicalNameSet(_ names: [String]) -> Set<String> {
+    Set(names.map(canonicalFacultyName))
+}
+
+let primaryMHICohort = CohortDefinition(
+    key: "mhi_uw_hi_researchers",
+    label: "MHI (UW Health Informatics Researchers)",
+    members: canonicalNameSet(MHIFacultyNames)
+)
+
+let biasConcernCohort = CohortDefinition(
+    key: "bias_concern_sensitivity",
+    label: "Bias-Concern Sensitivity Cohort",
+    members: canonicalNameSet(BiasConcernFacultyNames)
+)
+
+var analysisCohorts: [CohortDefinition] {
+    var cohorts = [primaryMHICohort]
+    if !biasConcernCohort.members.isEmpty {
+        cohorts.append(biasConcernCohort)
+    }
+    return cohorts
+}
+
+func isInPrimaryMHICohort(_ fullName: String) -> Bool {
+    primaryMHICohort.members.contains(canonicalFacultyName(fullName))
+}

--- a/SalaryData/MHI Faculty List.swift
+++ b/SalaryData/MHI Faculty List.swift
@@ -5,8 +5,8 @@
 //  Created by Jim Wallace on 2025-02-19.
 //
 
-
-// https://uwaterloo.ca/public-health-sciences/our-people/health-informatics-researchers
+// Source: https://uwaterloo.ca/public-health-sciences/our-people/health-informatics-researchers
+// Includes Hao Luo ("LUO, HAO").
 
 let MHIFacultyNames: [String] = [
     "CHAURASIA, ASHOK",

--- a/SalaryData/MHI Faculty List.swift
+++ b/SalaryData/MHI Faculty List.swift
@@ -1,0 +1,22 @@
+//
+//  MHI Faculty List.swift
+//  SalaryData
+//
+//  Created by Jim Wallace on 2025-02-19.
+//
+
+
+// https://uwaterloo.ca/public-health-sciences/our-people/health-informatics-researchers
+
+let MHIFacultyNames: [String] = [
+    "CHAURASIA, ASHOK",
+    "CHEN, HELEN H.",
+    "HIRDES, JOHN",
+    "LIU, LILI",
+    "LUO, HAO",
+    "MORITA, PLINIO",
+    "TORRES ESPIN, ABEL",
+    "WALLACE, JAMES R.",
+    "MCKILLOP, IAN",
+    "AROCHA, JOSE"
+]

--- a/SalaryData/Regression by MHI.swift
+++ b/SalaryData/Regression by MHI.swift
@@ -1,116 +1,415 @@
 import Foundation
 
-// Helper functions for matrix operations.
-func multiply(_ A: [[Double]], _ B: [[Double]]) -> [[Double]] {
-    let m = A.count, n = A[0].count, p = B[0].count
-    var result = Array(repeating: Array(repeating: 0.0, count: p), count: m)
-    for i in 0..<m {
-        for j in 0..<p {
-            for k in 0..<n {
-                result[i][j] += A[i][k] * B[k][j]
+struct OLSResult {
+    let variableNames: [String]
+    let coefficients: [Double]
+    let covariance: [[Double]]
+    let standardErrors: [Double]
+    let nObs: Int
+    let nClusters: Int
+}
+
+struct SummaryRow {
+    let model: String
+    let term: String
+    let estimate: Double
+    let standardError: Double
+    let ciLower: Double
+    let ciUpper: Double
+    let nObs: Int
+    let nClusters: Int
+}
+
+struct AnalysisRow {
+    let personID: String
+    let yearCentered: Double
+    let salary: Double
+    let mhi: Double
+}
+
+func transpose(_ matrix: [[Double]]) -> [[Double]] {
+    guard let columnCount = matrix.first?.count else { return [] }
+    var output = Array(repeating: Array(repeating: 0.0, count: matrix.count), count: columnCount)
+    for rowIndex in matrix.indices {
+        for colIndex in matrix[rowIndex].indices {
+            output[colIndex][rowIndex] = matrix[rowIndex][colIndex]
+        }
+    }
+    return output
+}
+
+func multiply(_ lhs: [[Double]], _ rhs: [[Double]]) -> [[Double]] {
+    guard let sharedCount = lhs.first?.count,
+          let rhsColumnCount = rhs.first?.count,
+          sharedCount == rhs.count else {
+        return []
+    }
+
+    var output = Array(repeating: Array(repeating: 0.0, count: rhsColumnCount), count: lhs.count)
+    for i in 0..<lhs.count {
+        for j in 0..<rhsColumnCount {
+            var sum = 0.0
+            for k in 0..<sharedCount {
+                sum += lhs[i][k] * rhs[k][j]
             }
+            output[i][j] = sum
         }
     }
-    return result
+    return output
 }
 
-func transpose(_ A: [[Double]]) -> [[Double]] {
-    let m = A.count, n = A[0].count
-    var result = Array(repeating: Array(repeating: 0.0, count: m), count: n)
-    for i in 0..<m {
-        for j in 0..<n {
-            result[j][i] = A[i][j]
+func matrixVectorMultiply(_ matrix: [[Double]], _ vector: [Double]) -> [Double] {
+    guard let columnCount = matrix.first?.count, columnCount == vector.count else { return [] }
+    var output = Array(repeating: 0.0, count: matrix.count)
+    for i in matrix.indices {
+        var sum = 0.0
+        for j in 0..<columnCount {
+            sum += matrix[i][j] * vector[j]
         }
+        output[i] = sum
     }
-    return result
+    return output
 }
 
-func invertMatrix(_ A: [[Double]]) -> [[Double]]? {
-    let n = A.count
-    var A = A  // mutable copy
-    var inv = Array(repeating: Array(repeating: 0.0, count: n), count: n)
-    for i in 0..<n { inv[i][i] = 1.0 }
-    
+func invertMatrix(_ input: [[Double]]) -> [[Double]]? {
+    let n = input.count
+    guard n > 0, input.allSatisfy({ $0.count == n }) else { return nil }
+
+    var matrix = input
+    var inverse = Array(repeating: Array(repeating: 0.0, count: n), count: n)
+    for i in 0..<n { inverse[i][i] = 1.0 }
+
     for i in 0..<n {
-        var pivot = A[i][i]
-        if abs(pivot) < 1e-10 {
-            var swapRow = i + 1
-            while swapRow < n && abs(A[swapRow][i]) < 1e-10 { swapRow += 1 }
-            if swapRow == n { return nil }
-            A.swapAt(i, swapRow)
-            inv.swapAt(i, swapRow)
-            pivot = A[i][i]
+        var pivotRow = i
+        for candidate in i..<n {
+            if abs(matrix[candidate][i]) > abs(matrix[pivotRow][i]) {
+                pivotRow = candidate
+            }
         }
-        
+
+        if abs(matrix[pivotRow][i]) < 1e-12 { return nil }
+        if pivotRow != i {
+            matrix.swapAt(i, pivotRow)
+            inverse.swapAt(i, pivotRow)
+        }
+
+        let pivot = matrix[i][i]
         for j in 0..<n {
-            A[i][j] /= pivot
-            inv[i][j] /= pivot
+            matrix[i][j] /= pivot
+            inverse[i][j] /= pivot
         }
-        
-        for k in 0..<n where k != i {
-            let factor = A[k][i]
-            for j in 0..<n {
-                A[k][j] -= factor * A[i][j]
-                inv[k][j] -= factor * inv[i][j]
+
+        for row in 0..<n where row != i {
+            let factor = matrix[row][i]
+            for col in 0..<n {
+                matrix[row][col] -= factor * matrix[i][col]
+                inverse[row][col] -= factor * inverse[i][col]
             }
         }
     }
-    return inv
+    return inverse
 }
 
-// Perform regression across MHI and non-MHI faculty.
-func regressionAnalysisMHI(records: [SalaryRecord]) {
-    let n = records.count
-    guard n > 0 else { return }
-    
-    // Construct the design matrix X with columns:
-    // [1, Year, mhiIndicator, Year * mhiIndicator]
-    var X = [[Double]](repeating: [Double](repeating: 0.0, count: 4), count: n)
-    var y = [Double](repeating: 0.0, count: n)
-    
-    for (i, record) in records.enumerated() {
-        let mhiIndicator = record.mhi ? 1.0 : 0.0
-        X[i][0] = 1.0
-        X[i][1] = Double(record.year)
-        X[i][2] = mhiIndicator
-        X[i][3] = Double(record.year) * mhiIndicator
-        y[i] = record.salary
+func outerProduct(_ lhs: [Double], _ rhs: [Double]) -> [[Double]] {
+    var output = Array(repeating: Array(repeating: 0.0, count: rhs.count), count: lhs.count)
+    for i in lhs.indices {
+        for j in rhs.indices {
+            output[i][j] = lhs[i] * rhs[j]
+        }
     }
-    
+    return output
+}
+
+func addInPlace(_ lhs: inout [[Double]], _ rhs: [[Double]]) {
+    guard lhs.count == rhs.count else { return }
+    for i in lhs.indices {
+        guard lhs[i].count == rhs[i].count else { return }
+        for j in lhs[i].indices {
+            lhs[i][j] += rhs[i][j]
+        }
+    }
+}
+
+func scaleMatrix(_ matrix: [[Double]], by factor: Double) -> [[Double]] {
+    var output = matrix
+    for i in output.indices {
+        for j in output[i].indices {
+            output[i][j] *= factor
+        }
+    }
+    return output
+}
+
+func runClusterRobustOLS(
+    X: [[Double]],
+    y: [Double],
+    clusterIDs: [String],
+    variableNames: [String]
+) -> OLSResult? {
+    let n = X.count
+    guard n > 0, y.count == n, clusterIDs.count == n else { return nil }
+    guard let k = X.first?.count, k > 0, variableNames.count == k else { return nil }
+    guard X.allSatisfy({ $0.count == k }) else { return nil }
+
     let Xt = transpose(X)
     let XtX = multiply(Xt, X)
-    
-    guard let XtXInv = invertMatrix(XtX) else {
-        print("Matrix inversion failed.")
-        return
-    }
-    
-    // Compute Xᵀy
-    var Xty = [Double](repeating: 0.0, count: 4)
-    for i in 0..<4 {
-        for j in 0..<n {
-            Xty[i] += Xt[i][j] * y[j]
+    guard let XtXInv = invertMatrix(XtX) else { return nil }
+
+    var Xty = Array(repeating: 0.0, count: k)
+    for i in 0..<k {
+        var sum = 0.0
+        for row in 0..<n {
+            sum += Xt[i][row] * y[row]
         }
+        Xty[i] = sum
     }
-    
-    // Calculate beta = (XᵀX)⁻¹ Xᵀy
-    var beta = [Double](repeating: 0.0, count: 4)
-    for i in 0..<4 {
-        for j in 0..<4 {
-            beta[i] += XtXInv[i][j] * Xty[j]
+    let coefficients = matrixVectorMultiply(XtXInv, Xty)
+
+    var residuals = Array(repeating: 0.0, count: n)
+    for row in 0..<n {
+        var fitted = 0.0
+        for col in 0..<k {
+            fitted += X[row][col] * coefficients[col]
         }
+        residuals[row] = y[row] - fitted
     }
-    
-    // Output regression coefficients.
-    print("Regression Coefficients:")
-    print("Intercept: \(beta[0])")
-    print("Year: \(beta[1])")
-    print("MHI Indicator: \(beta[2])")
-    print("Interaction (Year * MHI): \(beta[3])")
-    
-    // Interpretation:
-    // For non-MHI faculty: salary = beta[0] + beta[1]*year.
-    // For MHI faculty: salary = (beta[0] + beta[2]) + (beta[1] + beta[3])*year.
-    // Here, beta[3] quantifies the difference in the annual salary growth rate between MHI and non-MHI faculty.
+
+    var clusterToIndices: [String: [Int]] = [:]
+    for (index, clusterID) in clusterIDs.enumerated() {
+        clusterToIndices[clusterID, default: []].append(index)
+    }
+    let clusterCount = clusterToIndices.count
+    guard clusterCount > 1 else { return nil }
+
+    var meat = Array(repeating: Array(repeating: 0.0, count: k), count: k)
+    for indices in clusterToIndices.values {
+        var score = Array(repeating: 0.0, count: k)
+        for row in indices {
+            for col in 0..<k {
+                score[col] += X[row][col] * residuals[row]
+            }
+        }
+        addInPlace(&meat, outerProduct(score, score))
+    }
+
+    let nDouble = Double(n)
+    let kDouble = Double(k)
+    let gDouble = Double(clusterCount)
+    let correction = (gDouble / (gDouble - 1.0)) * ((nDouble - 1.0) / (nDouble - kDouble))
+
+    let covariance = scaleMatrix(multiply(multiply(XtXInv, meat), XtXInv), by: correction)
+    let standardErrors = (0..<k).map { sqrt(max(covariance[$0][$0], 0.0)) }
+
+    return OLSResult(
+        variableNames: variableNames,
+        coefficients: coefficients,
+        covariance: covariance,
+        standardErrors: standardErrors,
+        nObs: n,
+        nClusters: clusterCount
+    )
 }
 
+func confidenceInterval95(estimate: Double, standardError: Double) -> (Double, Double) {
+    let margin = 1.96 * standardError
+    return (estimate - margin, estimate + margin)
+}
+
+func modelRowsFromRecords(_ records: [SalaryRecord]) -> [AnalysisRow] {
+    guard let minYear = records.map(\.year).min() else { return [] }
+    let baseYear = Double(minYear)
+    return records.map { record in
+        AnalysisRow(
+            personID: "\(record.surname), \(record.givenName)",
+            yearCentered: Double(record.year) - baseYear,
+            salary: record.salary,
+            mhi: record.mhi ? 1.0 : 0.0
+        )
+    }
+}
+
+func pooledModel(_ rows: [AnalysisRow]) -> OLSResult? {
+    let X = rows.map { row in
+        [1.0, row.yearCentered, row.mhi, row.yearCentered * row.mhi]
+    }
+    let y = rows.map(\.salary)
+    let clusterIDs = rows.map(\.personID)
+    return runClusterRobustOLS(
+        X: X,
+        y: y,
+        clusterIDs: clusterIDs,
+        variableNames: ["Intercept", "YearCentered", "MHI", "YearCenteredXMHI"]
+    )
+}
+
+func fixedEffectsModel(_ rows: [AnalysisRow]) -> OLSResult? {
+    let grouped = Dictionary(grouping: rows, by: \.personID)
+    var transformedX: [[Double]] = []
+    var transformedY: [Double] = []
+    var transformedClusterIDs: [String] = []
+
+    for (personID, personRows) in grouped {
+        guard personRows.count >= 2 else { continue }
+
+        let meanY = personRows.map(\.salary).reduce(0.0, +) / Double(personRows.count)
+        let meanYear = personRows.map(\.yearCentered).reduce(0.0, +) / Double(personRows.count)
+        let interactions = personRows.map { $0.yearCentered * $0.mhi }
+        let meanInteraction = interactions.reduce(0.0, +) / Double(personRows.count)
+
+        for row in personRows {
+            let x1 = row.yearCentered - meanYear
+            let x2 = (row.yearCentered * row.mhi) - meanInteraction
+            transformedX.append([x1, x2])
+            transformedY.append(row.salary - meanY)
+            transformedClusterIDs.append(personID)
+        }
+    }
+
+    return runClusterRobustOLS(
+        X: transformedX,
+        y: transformedY,
+        clusterIDs: transformedClusterIDs,
+        variableNames: ["YearCentered", "YearCenteredXMHI"]
+    )
+}
+
+func slopeSummaryRows(modelName: String, result: OLSResult, slopeIndex: Int, interactionIndex: Int) -> [SummaryRow] {
+    let nonMHISlope = result.coefficients[slopeIndex]
+    let nonMHISE = result.standardErrors[slopeIndex]
+    let nonMHICI = confidenceInterval95(estimate: nonMHISlope, standardError: nonMHISE)
+
+    let interaction = result.coefficients[interactionIndex]
+    let interactionSE = result.standardErrors[interactionIndex]
+    let interactionCI = confidenceInterval95(estimate: interaction, standardError: interactionSE)
+
+    let mhiSlope = nonMHISlope + interaction
+    let mhiVar = result.covariance[slopeIndex][slopeIndex]
+        + result.covariance[interactionIndex][interactionIndex]
+        + 2.0 * result.covariance[slopeIndex][interactionIndex]
+    let mhiSE = sqrt(max(mhiVar, 0.0))
+    let mhiCI = confidenceInterval95(estimate: mhiSlope, standardError: mhiSE)
+
+    return [
+        SummaryRow(
+            model: modelName,
+            term: "Non-MHI annual slope",
+            estimate: nonMHISlope,
+            standardError: nonMHISE,
+            ciLower: nonMHICI.0,
+            ciUpper: nonMHICI.1,
+            nObs: result.nObs,
+            nClusters: result.nClusters
+        ),
+        SummaryRow(
+            model: modelName,
+            term: "MHI annual slope",
+            estimate: mhiSlope,
+            standardError: mhiSE,
+            ciLower: mhiCI.0,
+            ciUpper: mhiCI.1,
+            nObs: result.nObs,
+            nClusters: result.nClusters
+        ),
+        SummaryRow(
+            model: modelName,
+            term: "MHI - Non-MHI annual slope",
+            estimate: interaction,
+            standardError: interactionSE,
+            ciLower: interactionCI.0,
+            ciUpper: interactionCI.1,
+            nObs: result.nObs,
+            nClusters: result.nClusters
+        )
+    ]
+}
+
+func csvEscaped(_ field: String) -> String {
+    if field.contains(",") || field.contains("\"") || field.contains("\n") {
+        return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+    return field
+}
+
+func format(_ value: Double) -> String {
+    String(format: "%.3f", value)
+}
+
+func writeSummaryOutputs(rows: [SummaryRow]) {
+    let fileManager = FileManager.default
+    let outputDirectory = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        .appendingPathComponent("analysis_output", isDirectory: true)
+
+    do {
+        try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true, attributes: nil)
+
+        var csv = "model,term,estimate,std_error,ci_lower,ci_upper,n_obs,n_clusters\n"
+        var txt = "Regression summary (cluster-robust SE by person)\n\n"
+
+        for row in rows {
+            csv += [
+                row.model,
+                row.term,
+                format(row.estimate),
+                format(row.standardError),
+                format(row.ciLower),
+                format(row.ciUpper),
+                "\(row.nObs)",
+                "\(row.nClusters)"
+            ].map(csvEscaped).joined(separator: ",") + "\n"
+
+            txt += "\(row.model) | \(row.term): "
+            txt += "estimate=\(format(row.estimate)), "
+            txt += "SE=\(format(row.standardError)), "
+            txt += "95% CI [\(format(row.ciLower)), \(format(row.ciUpper))], "
+            txt += "N=\(row.nObs), clusters=\(row.nClusters)\n"
+        }
+
+        let csvURL = outputDirectory.appendingPathComponent("regression_summary.csv")
+        let txtURL = outputDirectory.appendingPathComponent("regression_summary.txt")
+        try csv.write(to: csvURL, atomically: true, encoding: .utf8)
+        try txt.write(to: txtURL, atomically: true, encoding: .utf8)
+
+        print("Wrote regression CSV summary: \(csvURL.path)")
+        print("Wrote regression text summary: \(txtURL.path)")
+    } catch {
+        print("Failed to write regression summary outputs: \(error)")
+    }
+}
+
+func regressionAnalysisMHI(records: [SalaryRecord]) {
+    let rows = modelRowsFromRecords(records)
+    guard !rows.isEmpty else {
+        print("No records available for regression.")
+        return
+    }
+
+    guard let pooled = pooledModel(rows) else {
+        print("Pooled model failed.")
+        return
+    }
+    guard let fixedEffects = fixedEffectsModel(rows) else {
+        print("Fixed-effects model failed.")
+        return
+    }
+
+    let pooledSummary = slopeSummaryRows(
+        modelName: "Pooled OLS (cluster-robust)",
+        result: pooled,
+        slopeIndex: 1,
+        interactionIndex: 3
+    )
+    let fixedEffectsSummary = slopeSummaryRows(
+        modelName: "Person FE (cluster-robust)",
+        result: fixedEffects,
+        slopeIndex: 0,
+        interactionIndex: 1
+    )
+
+    let allRows = pooledSummary + fixedEffectsSummary
+    writeSummaryOutputs(rows: allRows)
+
+    print("Regression Summary:")
+    for row in allRows {
+        print("\(row.model) | \(row.term) = \(format(row.estimate)) (SE \(format(row.standardError)))")
+    }
+}

--- a/SalaryData/Regression by MHI.swift
+++ b/SalaryData/Regression by MHI.swift
@@ -215,15 +215,16 @@ func confidenceInterval95(estimate: Double, standardError: Double) -> (Double, D
     return (estimate - margin, estimate + margin)
 }
 
-func modelRowsFromRecords(_ records: [SalaryRecord]) -> [AnalysisRow] {
+func modelRowsFromRecords(_ records: [SalaryRecord], cohort: CohortDefinition) -> [AnalysisRow] {
     guard let minYear = records.map(\.year).min() else { return [] }
     let baseYear = Double(minYear)
     return records.map { record in
-        AnalysisRow(
-            personID: "\(record.surname), \(record.givenName)",
+        let fullName = "\(record.surname), \(record.givenName)"
+        return AnalysisRow(
+            personID: fullName,
             yearCentered: Double(record.year) - baseYear,
             salary: record.salary,
-            mhi: record.mhi ? 1.0 : 0.0
+            mhi: cohort.members.contains(canonicalFacultyName(fullName)) ? 1.0 : 0.0
         )
     }
 }
@@ -334,7 +335,7 @@ func format(_ value: Double) -> String {
     String(format: "%.3f", value)
 }
 
-func writeSummaryOutputs(rows: [SummaryRow]) {
+func writeSummaryOutputs(rows: [SummaryRow], fileStem: String, cohortLabel: String) {
     let fileManager = FileManager.default
     let outputDirectory = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
         .appendingPathComponent("analysis_output", isDirectory: true)
@@ -343,7 +344,8 @@ func writeSummaryOutputs(rows: [SummaryRow]) {
         try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true, attributes: nil)
 
         var csv = "model,term,estimate,std_error,ci_lower,ci_upper,n_obs,n_clusters\n"
-        var txt = "Regression summary (cluster-robust SE by person)\n\n"
+        var txt = "Regression summary (cluster-robust SE by person)\n"
+        txt += "Cohort definition: \(cohortLabel)\n\n"
 
         for row in rows {
             csv += [
@@ -364,8 +366,8 @@ func writeSummaryOutputs(rows: [SummaryRow]) {
             txt += "N=\(row.nObs), clusters=\(row.nClusters)\n"
         }
 
-        let csvURL = outputDirectory.appendingPathComponent("regression_summary.csv")
-        let txtURL = outputDirectory.appendingPathComponent("regression_summary.txt")
+        let csvURL = outputDirectory.appendingPathComponent("\(fileStem).csv")
+        let txtURL = outputDirectory.appendingPathComponent("\(fileStem).txt")
         try csv.write(to: csvURL, atomically: true, encoding: .utf8)
         try txt.write(to: txtURL, atomically: true, encoding: .utf8)
 
@@ -377,39 +379,51 @@ func writeSummaryOutputs(rows: [SummaryRow]) {
 }
 
 func regressionAnalysisMHI(records: [SalaryRecord]) {
-    let rows = modelRowsFromRecords(records)
-    guard !rows.isEmpty else {
+    guard !records.isEmpty else {
         print("No records available for regression.")
         return
     }
 
-    guard let pooled = pooledModel(rows) else {
-        print("Pooled model failed.")
-        return
-    }
-    guard let fixedEffects = fixedEffectsModel(rows) else {
-        print("Fixed-effects model failed.")
-        return
-    }
+    for cohort in analysisCohorts {
+        let rows = modelRowsFromRecords(records, cohort: cohort)
+        let treatedCount = rows.filter { $0.mhi == 1.0 }.count
+        let untreatedCount = rows.count - treatedCount
+        guard treatedCount > 1, untreatedCount > 1 else {
+            print("Skipping cohort '\(cohort.label)' because one group has too few observations.")
+            continue
+        }
 
-    let pooledSummary = slopeSummaryRows(
-        modelName: "Pooled OLS (cluster-robust)",
-        result: pooled,
-        slopeIndex: 1,
-        interactionIndex: 3
-    )
-    let fixedEffectsSummary = slopeSummaryRows(
-        modelName: "Person FE (cluster-robust)",
-        result: fixedEffects,
-        slopeIndex: 0,
-        interactionIndex: 1
-    )
+        guard let pooled = pooledModel(rows) else {
+            print("Pooled model failed for cohort: \(cohort.label)")
+            continue
+        }
+        guard let fixedEffects = fixedEffectsModel(rows) else {
+            print("Fixed-effects model failed for cohort: \(cohort.label)")
+            continue
+        }
 
-    let allRows = pooledSummary + fixedEffectsSummary
-    writeSummaryOutputs(rows: allRows)
+        let pooledSummary = slopeSummaryRows(
+            modelName: "Pooled OLS (cluster-robust)",
+            result: pooled,
+            slopeIndex: 1,
+            interactionIndex: 3
+        )
+        let fixedEffectsSummary = slopeSummaryRows(
+            modelName: "Person FE (cluster-robust)",
+            result: fixedEffects,
+            slopeIndex: 0,
+            interactionIndex: 1
+        )
 
-    print("Regression Summary:")
-    for row in allRows {
-        print("\(row.model) | \(row.term) = \(format(row.estimate)) (SE \(format(row.standardError)))")
+        let allRows = pooledSummary + fixedEffectsSummary
+        let fileStem = cohort.key == primaryMHICohort.key
+            ? "regression_summary"
+            : "regression_summary_\(cohort.key)"
+        writeSummaryOutputs(rows: allRows, fileStem: fileStem, cohortLabel: cohort.label)
+
+        print("Regression Summary for \(cohort.label):")
+        for row in allRows {
+            print("\(row.model) | \(row.term) = \(format(row.estimate)) (SE \(format(row.standardError)))")
+        }
     }
 }

--- a/SalaryData/Regression by MHI.swift
+++ b/SalaryData/Regression by MHI.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+// Helper functions for matrix operations.
+func multiply(_ A: [[Double]], _ B: [[Double]]) -> [[Double]] {
+    let m = A.count, n = A[0].count, p = B[0].count
+    var result = Array(repeating: Array(repeating: 0.0, count: p), count: m)
+    for i in 0..<m {
+        for j in 0..<p {
+            for k in 0..<n {
+                result[i][j] += A[i][k] * B[k][j]
+            }
+        }
+    }
+    return result
+}
+
+func transpose(_ A: [[Double]]) -> [[Double]] {
+    let m = A.count, n = A[0].count
+    var result = Array(repeating: Array(repeating: 0.0, count: m), count: n)
+    for i in 0..<m {
+        for j in 0..<n {
+            result[j][i] = A[i][j]
+        }
+    }
+    return result
+}
+
+func invertMatrix(_ A: [[Double]]) -> [[Double]]? {
+    let n = A.count
+    var A = A  // mutable copy
+    var inv = Array(repeating: Array(repeating: 0.0, count: n), count: n)
+    for i in 0..<n { inv[i][i] = 1.0 }
+    
+    for i in 0..<n {
+        var pivot = A[i][i]
+        if abs(pivot) < 1e-10 {
+            var swapRow = i + 1
+            while swapRow < n && abs(A[swapRow][i]) < 1e-10 { swapRow += 1 }
+            if swapRow == n { return nil }
+            A.swapAt(i, swapRow)
+            inv.swapAt(i, swapRow)
+            pivot = A[i][i]
+        }
+        
+        for j in 0..<n {
+            A[i][j] /= pivot
+            inv[i][j] /= pivot
+        }
+        
+        for k in 0..<n where k != i {
+            let factor = A[k][i]
+            for j in 0..<n {
+                A[k][j] -= factor * A[i][j]
+                inv[k][j] -= factor * inv[i][j]
+            }
+        }
+    }
+    return inv
+}
+
+// Perform regression across MHI and non-MHI faculty.
+func regressionAnalysisMHI(records: [SalaryRecord]) {
+    let n = records.count
+    guard n > 0 else { return }
+    
+    // Construct the design matrix X with columns:
+    // [1, Year, mhiIndicator, Year * mhiIndicator]
+    var X = [[Double]](repeating: [Double](repeating: 0.0, count: 4), count: n)
+    var y = [Double](repeating: 0.0, count: n)
+    
+    for (i, record) in records.enumerated() {
+        let mhiIndicator = record.mhi ? 1.0 : 0.0
+        X[i][0] = 1.0
+        X[i][1] = Double(record.year)
+        X[i][2] = mhiIndicator
+        X[i][3] = Double(record.year) * mhiIndicator
+        y[i] = record.salary
+    }
+    
+    let Xt = transpose(X)
+    let XtX = multiply(Xt, X)
+    
+    guard let XtXInv = invertMatrix(XtX) else {
+        print("Matrix inversion failed.")
+        return
+    }
+    
+    // Compute Xᵀy
+    var Xty = [Double](repeating: 0.0, count: 4)
+    for i in 0..<4 {
+        for j in 0..<n {
+            Xty[i] += Xt[i][j] * y[j]
+        }
+    }
+    
+    // Calculate beta = (XᵀX)⁻¹ Xᵀy
+    var beta = [Double](repeating: 0.0, count: 4)
+    for i in 0..<4 {
+        for j in 0..<4 {
+            beta[i] += XtXInv[i][j] * Xty[j]
+        }
+    }
+    
+    // Output regression coefficients.
+    print("Regression Coefficients:")
+    print("Intercept: \(beta[0])")
+    print("Year: \(beta[1])")
+    print("MHI Indicator: \(beta[2])")
+    print("Interaction (Year * MHI): \(beta[3])")
+    
+    // Interpretation:
+    // For non-MHI faculty: salary = beta[0] + beta[1]*year.
+    // For MHI faculty: salary = (beta[0] + beta[2]) + (beta[1] + beta[3])*year.
+    // Here, beta[3] quantifies the difference in the annual salary growth rate between MHI and non-MHI faculty.
+}
+

--- a/SalaryData/Regression.swift
+++ b/SalaryData/Regression.swift
@@ -1,0 +1,80 @@
+//
+//  Regression.swift
+//  SalaryData
+//
+//  Created by Jim Wallace on 2025-02-19.
+//
+
+import Foundation
+
+func linearRegressionContinuous(for records: [SalaryRecord]) -> (slope: Double, intercept: Double)? {
+    // Sort records by year.
+    let sortedRecords = records.sorted { $0.year < $1.year }
+    guard !sortedRecords.isEmpty else { return nil }
+    
+    // Partition into continuous segments (consecutive years).
+    var segments: [[SalaryRecord]] = []
+    var currentSegment: [SalaryRecord] = [sortedRecords[0]]
+    
+    for record in sortedRecords.dropFirst() {
+        if record.year == currentSegment.last!.year + 1 {
+            currentSegment.append(record)
+        } else {
+            segments.append(currentSegment)
+            currentSegment = [record]
+        }
+    }
+    segments.append(currentSegment)
+    
+    // Choose the longest continuous segment.
+    guard let longestSegment = segments.max(by: { $0.count < $1.count }),
+          longestSegment.count >= 2 else { return nil }
+    
+    let n = Double(longestSegment.count)
+    let sumX = longestSegment.reduce(0.0) { $0 + Double($1.year) }
+    let sumY = longestSegment.reduce(0.0) { $0 + $1.salary }
+    let sumXY = longestSegment.reduce(0.0) { $0 + Double($1.year) * $1.salary }
+    let sumXX = longestSegment.reduce(0.0) { $0 + pow(Double($1.year), 2) }
+    
+    let denominator = n * sumXX - pow(sumX, 2)
+    guard denominator != 0 else { return nil }
+    
+    let slope = (n * sumXY - sumX * sumY) / denominator
+    let intercept = (sumY - slope * sumX) / n
+    
+    return (slope, intercept)
+}
+
+func analyzeSalaries(records: [SalaryRecord], for targetFullName: String) {
+    // Group records by full name.
+    let groupedRecords = Dictionary(grouping: records, by: { $0.fullName })
+    
+    var regressionResults: [String: (slope: Double, intercept: Double)] = [:]
+    for (name, recs) in groupedRecords {
+        let sortedRecords = recs.sorted { $0.year < $1.year }
+        if let regression = linearRegressionContinuous(for: sortedRecords) {
+            regressionResults[name] = regression
+        }
+    }
+    
+    guard let targetRegression = regressionResults[targetFullName] else {
+        print("No data found for \(targetFullName).")
+        for r in regressionResults {
+            print(r)
+        }
+        return
+    }
+    
+    print("Regression for \(targetFullName): Slope = \(targetRegression.slope), Intercept = \(targetRegression.intercept)")
+    
+    for (name, regression) in regressionResults where name != targetFullName {
+        print("Regression for \(name): Slope = \(regression.slope), Intercept = \(regression.intercept)")
+        if regression.slope > targetRegression.slope {
+            print("\(name)'s salary is growing faster than \(targetFullName)'s.\n")
+        } else if regression.slope < targetRegression.slope {
+            print("\(name)'s salary is growing slower than \(targetFullName)'s.\n")
+        } else {
+            print("\(name)'s salary growth rate is similar to \(targetFullName)'s.\n")
+        }
+    }
+}

--- a/SalaryData/SPHS Faculty List.swift
+++ b/SalaryData/SPHS Faculty List.swift
@@ -1,0 +1,53 @@
+//
+//  Faculty List.swift
+//  SalaryData
+//
+//  Created by Jim Wallace on 2025-02-19.
+//
+
+let SPHSFacultyNames: [String] = [
+    "ANTHONY, KELLY K.",
+    "BARDWELL, GEOFFREY",
+    "BIELOW, PHILIP L.",
+    "BUTT, ZAHID",
+    "CHAURASIA, ASHOK",
+    "CHEN, HELEN H.",
+    "COOKE, MARTIN J.",
+    "DODD, WARREN",
+    "DUBIN, JOEL A.",
+    "FERRO, MARK",
+    "GOEL, VIVEK",
+    "HALL, PETER A.",
+    "HAMMOND, DAVID",
+    "HIRDES, JOHN",
+    "JANDU, NARVEEN",
+    "KIRKPATRICK, SHARON",
+    "LAIRD, BRIAN",
+    "LAW, JANE",
+    "LEATHERDALE, SCOTT",
+    "LIU, LILI",
+    "LUO, HAO",
+    "MACEACHEN (STOTHERS), ELLEN",
+    "MAJOWICZ, SHANNON",
+    "MCAINEY, CARRIE",
+    "MEYER, SAMANTHA",
+    "MIELKE, JOHN G.",
+    "MORITA, PLINIO",
+    "NEITERMAN, ELENA",
+    "TAIT NEUFELD, HANNAH",
+    "OGA-OMENKA, CHARITY",
+    "OREMUS, MARK",
+    "PERLMAN, CHRISTOPHER",
+    "SKINNER, KELLY",
+    "TORRES ESPIN, ABEL",
+    "TYAS, SUZANNE L",
+    "WALLACE, JAMES R.",
+    "WILLIAMS, DIANE",
+    "YESSIS, JENNIFER L",
+    "MCKILLOP, IAN",
+    "AROCHA, JOSE",
+    "CORBET, KITTY KING",
+    "GARCIA, JOHN M",
+    "HANNING, RHONA",
+    "HORTON, SUSAN E."
+]

--- a/SalaryData/SalaryRecord.swift
+++ b/SalaryData/SalaryRecord.swift
@@ -1,0 +1,22 @@
+//
+//  SalaryRecord.swift
+//  SalaryData
+//
+//  Created by Jim Wallace on 2024-12-12.
+//
+
+import Foundation
+
+struct SalaryRecord: Codable {
+    let surname: String
+    let givenName: String
+    let position: String
+    let salary: Double
+    let taxableBenefits: Double
+    let year: Int
+    let mhi: Bool
+
+    var fullName: String {
+        return "\(givenName) \(surname)"
+    }
+}

--- a/SalaryData/SalaryScraper.swift
+++ b/SalaryData/SalaryScraper.swift
@@ -75,7 +75,7 @@ struct SalaryScraper {
                 let givenName = nameParts.count > 1 ? String(nameParts[1]).trimmingCharacters(in: .whitespaces) : ""
                 
                 // Add name and salaries for each year
-                let row = [surname, givenName, MHIFacultyNames.contains(name).description] + years.map { year in
+                let row = [surname, givenName, isInPrimaryMHICohort(name).description] + years.map { year in
                     if let salary = salaryByYear[year] {
                         return "\(salary)"
                     } else {
@@ -153,7 +153,7 @@ struct SalaryScraper {
 
                 let taxableBenefits = try Double(columns[4].text().replacingOccurrences(of: "[$,\\s]", with: "", options: .regularExpression)) ?? -1.0
                 
-                let mhi = MHIFacultyNames.contains(surname + ", " + givenName)
+                let mhi = isInPrimaryMHICohort(surname + ", " + givenName)
 
                 let record = SalaryRecord(surname: surname, givenName: givenName, position: position, salary: salary, taxableBenefits: taxableBenefits, year: year, mhi: mhi)
                 //print(record)                

--- a/SalaryData/SalaryScraper.swift
+++ b/SalaryData/SalaryScraper.swift
@@ -63,15 +63,19 @@ struct SalaryScraper {
         // Prepare CSV content
         do {
             
-            var csvContent = "Surame, Given name, MHI," + years.map { "\($0)" }.joined(separator: ",") + "\n"
+            var csvContent = "Surname,Given name,MHI," + years.map { "\($0)" }.joined(separator: ",") + "\n"
             for (name, records) in salaryDictionary {
                 var salaryByYear = [Int: Double]() // Map year to salary for quick lookup
                 for record in records {
                     salaryByYear[record.year] = record.salary
                 }
                 
+                let nameParts = name.split(separator: ",", maxSplits: 1, omittingEmptySubsequences: false)
+                let surname = nameParts.count > 0 ? String(nameParts[0]).trimmingCharacters(in: .whitespaces) : ""
+                let givenName = nameParts.count > 1 ? String(nameParts[1]).trimmingCharacters(in: .whitespaces) : ""
+                
                 // Add name and salaries for each year
-                let row = [name] + [ MHIFacultyNames.contains(name).description  ] + years.map { year in
+                let row = [surname, givenName, MHIFacultyNames.contains(name).description] + years.map { year in
                     if let salary = salaryByYear[year] {
                         return "\(salary)"
                     } else {
@@ -80,7 +84,7 @@ struct SalaryScraper {
                 }
                 
                 if SPHSFacultyNames.contains(name) {
-                    csvContent += row.joined(separator: ",") + "\n"
+                    csvContent += row.map(escapeCSVField).joined(separator: ",") + "\n"
                 }
             }
             
@@ -104,7 +108,20 @@ struct SalaryScraper {
             return []
         }
         
-        let (data, _) = try! await URLSession.shared.data(from: url)
+        let data: Data
+        do {
+            let (fetchedData, response) = try await URLSession.shared.data(from: url)
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200...299).contains(httpResponse.statusCode) {
+                print("Request failed for \(html) with status \(httpResponse.statusCode)")
+                return []
+            }
+            data = fetchedData
+        } catch {
+            print("Network request failed for \(html): \(error)")
+            return []
+        }
+        
         guard let htmlContent = String(data: data, encoding: .utf8) else {
             return []
         }
@@ -126,7 +143,7 @@ struct SalaryScraper {
                 }
                 
                 let columns = try row.select("th, td")
-                guard columns.count >= 3 else { continue }
+                guard columns.count >= 5 else { continue }
                 
                 let surname = try columns[0].text()
                 let givenName = try columns[1].text()
@@ -158,6 +175,13 @@ struct SalaryScraper {
             return Int(urlString[yearRange])
         }
         return nil
+    }
+
+    static func escapeCSVField(_ field: String) -> String {
+        if field.contains(",") || field.contains("\"") || field.contains("\n") {
+            return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
+        }
+        return field
     }
     
 }

--- a/SalaryData/SalaryScraper.swift
+++ b/SalaryData/SalaryScraper.swift
@@ -1,0 +1,163 @@
+//
+//  main.swift
+//  SalaryData
+//
+//  Created by Jim Wallace on 2024-12-12.
+//
+
+import Foundation
+import SwiftSoup
+
+
+
+
+
+@main
+struct SalaryScraper {
+    
+    static func main() async {
+        
+        let years = Array(2011...2024)
+        
+        let urls = [
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2011",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2012",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2013",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2014",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2015",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2016",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2017",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2018",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2019",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2020",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2021",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2022",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2023",
+            "https://uwaterloo.ca/about/accountability/salary-disclosure-2024"
+        ]
+        
+        
+        var results: [SalaryRecord] = []
+        
+        await withTaskGroup(of: [SalaryRecord].self) { taskGroup in
+            for urlString in urls {
+                taskGroup.addTask {
+                    return await parseHTML(urlString)
+                }
+            }
+            
+            for await records in taskGroup {
+                results.append(contentsOf: records)
+            }
+        }
+        results = results.filter{ SPHSFacultyNames.contains($0.surname + ", " + $0.givenName) }
+        
+        let salaryDictionary: [ String : [(year: Int, salary: Double)] ] = results.reduce(into: [:]) { dict, record in
+            dict["\(record.surname), \(record.givenName)", default: []].append( (year: record.year, salary: record.salary) )
+        }
+        
+        // Write data to file
+        let downloadsDirectory = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
+        let fileURL = downloadsDirectory.appendingPathComponent("sphs_dictionary.csv")
+
+        // Prepare CSV content
+        do {
+            
+            var csvContent = "Surame, Given name, MHI," + years.map { "\($0)" }.joined(separator: ",") + "\n"
+            for (name, records) in salaryDictionary {
+                var salaryByYear = [Int: Double]() // Map year to salary for quick lookup
+                for record in records {
+                    salaryByYear[record.year] = record.salary
+                }
+                
+                // Add name and salaries for each year
+                let row = [name] + [ MHIFacultyNames.contains(name).description  ] + years.map { year in
+                    if let salary = salaryByYear[year] {
+                        return "\(salary)"
+                    } else {
+                        return "" // Empty cell if no salary data for the year
+                    }
+                }
+                
+                if SPHSFacultyNames.contains(name) {
+                    csvContent += row.joined(separator: ",") + "\n"
+                }
+            }
+            
+            // Write CSV to the file
+            try csvContent.write(to: fileURL, atomically: true, encoding: .utf8)
+            print("Dictionary written to: \(fileURL.path)")
+        } catch {
+            print("Error writing dictionary to file: \(error)")
+        }
+            
+
+        //analyzeSalaries(records: results, for: "JAMES R. WALLACE")
+        regressionAnalysisMHI(records: results)
+        
+    }
+    
+    
+    static func parseHTML(_ html: String) async -> [SalaryRecord] {
+                
+        guard let url = URL(string: html) else {
+            return []
+        }
+        
+        let (data, _) = try! await URLSession.shared.data(from: url)
+        guard let htmlContent = String(data: data, encoding: .utf8) else {
+            return []
+        }
+        
+        var results: [SalaryRecord] = []
+        
+        let year = extractYear(from: html) ?? 0
+        
+        do {
+            let document = try SwiftSoup.parse(htmlContent)
+                        
+            let rows = try document.select("table tr")
+            
+            for row in rows {
+                
+                // Skip header rows (rows containing <th> in the first row)
+                if try row.select("th").count == row.childNodeSize() {
+                    continue
+                }
+                
+                let columns = try row.select("th, td")
+                guard columns.count >= 3 else { continue }
+                
+                let surname = try columns[0].text()
+                let givenName = try columns[1].text()
+                let position = try columns[2].text()
+                
+                let salary = try Double(columns[3].text().replacingOccurrences(of: "[$,\\s]", with: "", options: .regularExpression)) ?? -1.0
+
+                let taxableBenefits = try Double(columns[4].text().replacingOccurrences(of: "[$,\\s]", with: "", options: .regularExpression)) ?? -1.0
+                
+                let mhi = MHIFacultyNames.contains(surname + ", " + givenName)
+
+                let record = SalaryRecord(surname: surname, givenName: givenName, position: position, salary: salary, taxableBenefits: taxableBenefits, year: year, mhi: mhi)
+                //print(record)                
+                results.append(record)
+            }
+        } catch {
+            print("Error parsing HTML: \(error)")
+        }
+        
+        return results
+    }
+
+
+    static func extractYear(from urlString: String) -> Int? {
+        let regex = try? NSRegularExpression(pattern: "salary-disclosure-(\\d{4})")
+        let range = NSRange(location: 0, length: urlString.utf16.count)
+        if let match = regex?.firstMatch(in: urlString, options: [], range: range),
+           let yearRange = Range(match.range(at: 1), in: urlString) {
+            return Int(urlString[yearRange])
+        }
+        return nil
+    }
+    
+}

--- a/analysis_output/regression_summary.csv
+++ b/analysis_output/regression_summary.csv
@@ -1,0 +1,7 @@
+model,term,estimate,std_error,ci_lower,ci_upper,n_obs,n_clusters
+Pooled OLS (cluster-robust),Non-MHI annual slope,4404.586,1828.252,821.212,7987.959,315,40
+Pooled OLS (cluster-robust),MHI annual slope,3684.770,2374.465,-969.182,8338.722,315,40
+Pooled OLS (cluster-robust),MHI - Non-MHI annual slope,-719.815,2996.763,-6593.471,5153.840,315,40
+Person FE (cluster-robust),Non-MHI annual slope,7750.885,597.649,6579.493,8922.277,313,38
+Person FE (cluster-robust),MHI annual slope,6821.914,888.382,5080.686,8563.142,313,38
+Person FE (cluster-robust),MHI - Non-MHI annual slope,-928.971,1070.704,-3027.549,1169.608,313,38

--- a/analysis_output/regression_summary.txt
+++ b/analysis_output/regression_summary.txt
@@ -1,0 +1,8 @@
+Regression summary (cluster-robust SE by person)
+
+Pooled OLS (cluster-robust) | Non-MHI annual slope: estimate=4404.586, SE=1828.252, 95% CI [821.212, 7987.959], N=315, clusters=40
+Pooled OLS (cluster-robust) | MHI annual slope: estimate=3684.770, SE=2374.465, 95% CI [-969.182, 8338.722], N=315, clusters=40
+Pooled OLS (cluster-robust) | MHI - Non-MHI annual slope: estimate=-719.815, SE=2996.763, 95% CI [-6593.471, 5153.840], N=315, clusters=40
+Person FE (cluster-robust) | Non-MHI annual slope: estimate=7750.885, SE=597.649, 95% CI [6579.493, 8922.277], N=313, clusters=38
+Person FE (cluster-robust) | MHI annual slope: estimate=6821.914, SE=888.382, 95% CI [5080.686, 8563.142], N=313, clusters=38
+Person FE (cluster-robust) | MHI - Non-MHI annual slope: estimate=-928.971, SE=1070.704, 95% CI [-3027.549, 1169.608], N=313, clusters=38

--- a/analysis_output/regression_summary.txt
+++ b/analysis_output/regression_summary.txt
@@ -1,4 +1,5 @@
 Regression summary (cluster-robust SE by person)
+Cohort definition: MHI (UW Health Informatics Researchers)
 
 Pooled OLS (cluster-robust) | Non-MHI annual slope: estimate=4404.586, SE=1828.252, 95% CI [821.212, 7987.959], N=315, clusters=40
 Pooled OLS (cluster-robust) | MHI annual slope: estimate=3684.770, SE=2374.465, 95% CI [-969.182, 8338.722], N=315, clusters=40

--- a/main.tex
+++ b/main.tex
@@ -3,6 +3,8 @@
 \usepackage{amsmath}
 \usepackage{hyperref}
 \usepackage{biblatex}
+\usepackage{pgfplotstable}
+\pgfplotsset{compat=1.18}
 \addbibresource{bib.bib}
 \input{format}
 
@@ -21,12 +23,41 @@ To investigate potential salary discrepancies between faculty members affiliated
 
 \section{Analysis}
 
-Faculty members were categorized into two groups based on their MHI affiliation status. Average salary increases over the ten-year period were then computed for each group. Because the dataset represents the full population of faculty in the department, formal statistical inference was not required. Instead, descriptive comparisons and trend visualizations were used to illustrate the observed differences.
+Faculty members were categorized into MHI and non-MHI groups. Salary progression was estimated using two complementary models: (1) pooled OLS with a year-by-MHI interaction, and (2) a person fixed-effects model that controls for time-invariant faculty-level differences. Cluster-robust standard errors were computed at the faculty level, and summary results were exported automatically to \texttt{analysis\_output/regression\_summary.csv}.
 
 
 \section{Results}
 
-The analysis reveals a notable disparity in salary progression. Non-MHI faculty members experienced an average annual salary increase of approximately \$3,074, whereas MHI-affiliated faculty members saw a lower average of around \$1,541 per year. Over a ten-year span, this resulted in a cumulative difference of approximately \$15,330 in favour of non-MHI faculty. This disparity is consistent with a hypothesis of systemic bias in performance evaluation, especially given the interdisciplinary nature of the MHI program. 
+Both models estimated lower annual salary growth for MHI-affiliated faculty relative to non-MHI faculty, but uncertainty intervals for the MHI-minus-non-MHI slope difference include zero. This indicates the direction of the estimated difference is consistent across specifications, while statistical uncertainty remains material.
+\vspace{0.5em}
+
+\IfFileExists{analysis_output/regression_summary.csv}{
+\begin{table}[h]
+    \centering
+    \small
+    \resizebox{\textwidth}{!}{
+    \pgfplotstabletypeset[
+        col sep=comma,
+        string type,
+        columns={model,term,estimate,std_error,ci_lower,ci_upper,n_obs,n_clusters},
+        columns/model/.style={column name=Model},
+        columns/term/.style={column name=Term},
+        columns/estimate/.style={column name=Estimate},
+        columns/std_error/.style={column name=SE},
+        columns/ci_lower/.style={column name=CI Low},
+        columns/ci_upper/.style={column name=CI High},
+        columns/n_obs/.style={column name=N},
+        columns/n_clusters/.style={column name=Clusters},
+        every head row/.style={before row=\toprule,after row=\midrule},
+        every last row/.style={after row=\bottomrule}
+    ]{analysis_output/regression_summary.csv}
+    }
+    \caption{Regression estimates with cluster-robust standard errors (faculty-level clustering).}
+    \label{tab:regression_summary}
+\end{table}
+}{
+\textit{Regression summary CSV not found. Run the SalaryData executable to generate \texttt{analysis\_output/regression\_summary.csv}.}
+}
 \vspace{-10em}
 \begin{figure}[b]
     \centering
@@ -39,4 +70,3 @@ The analysis reveals a notable disparity in salary progression. Non-MHI faculty 
 \printbibliography
 
 \end{document}
-

--- a/main.tex
+++ b/main.tex
@@ -21,14 +21,23 @@
 To investigate potential salary discrepancies between faculty members affiliated with the Master of Health Informatics (MHI) program and those who are not (non-MHI) at the University of Waterloo, data was collected from the following sources: University of Waterloo public salary disclosures 2011--2024 \cite{uw_salary_2011, uw_salary_2012, uw_salary_2013, uw_salary_2014, uw_salary_2015, uw_salary_2016, uw_salary_2017, uw_salary_2018, uw_salary_2019, uw_salary_2020, uw_salary_2021, uw_salary_2022, uw_salary_2023, uw_salary_2024}, faculty association publications outlining salary structures \cite{fauw_salary_structure}, and School of Public Health Sciences faculty listings \cite{uwaterloo_mhi_faculty}. The data included annual salary figures, MHI affiliation status, and spanned a ten-year period to enable a longitudinal analysis of salary progression.
 
 
-\section{Analysis}
+\section{Methods}
 
-Faculty members were categorized into MHI and non-MHI groups. Salary progression was estimated using two complementary models: (1) pooled OLS with a year-by-MHI interaction, and (2) a person fixed-effects model that controls for time-invariant faculty-level differences. Cluster-robust standard errors were computed at the faculty level, and summary results were exported automatically to \texttt{analysis\_output/regression\_summary.csv}.
+Faculty members were categorized into MHI and non-MHI groups. Salary progression was estimated using two complementary models:
+\begin{enumerate}[leftmargin=*]
+    \item \textbf{Pooled OLS with interaction:} salary was modeled as a function of year, MHI status, and a year$\times$MHI interaction.
+    \item \textbf{Person fixed effects (FE):} the same slope comparison was estimated after removing time-invariant faculty-level differences.
+\end{enumerate}
+
+Year was centered at the first observed year to improve interpretation and numerical stability. In both models, the key quantity is the coefficient on the year$\times$MHI term, which measures the annual salary-growth difference (MHI minus non-MHI). Cluster-robust standard errors were computed at the faculty level, and 95\% confidence intervals were reported. Model outputs are generated programmatically and written to \texttt{analysis\_output/regression\_summary.csv}.
 
 
 \section{Results}
 
-Both models estimated lower annual salary growth for MHI-affiliated faculty relative to non-MHI faculty, but uncertainty intervals for the MHI-minus-non-MHI slope difference include zero. This indicates the direction of the estimated difference is consistent across specifications, while statistical uncertainty remains material.
+Table~\ref{tab:regression_summary} summarizes the estimated annual salary slopes and uncertainty intervals. In the pooled model, the MHI-minus-non-MHI annual slope estimate is approximately \(-719.8\) with a 95\% CI of roughly \([-6593.5,\ 5153.8]\). In the person FE model, the corresponding estimate is approximately \(-929.0\) with a 95\% CI of roughly \([-3027.5,\ 1169.6]\). Both point estimates indicate slower growth for MHI-affiliated faculty, but both confidence intervals include zero.
+\vspace{0.5em}
+
+The figure is still useful as a descriptive visualization of salary trajectories by affiliation group. However, it should be interpreted as exploratory rather than inferential, because it does not display the fixed-effects specification or confidence intervals used in the primary statistical comparison.
 \vspace{0.5em}
 
 \IfFileExists{analysis_output/regression_summary.csv}{
@@ -58,13 +67,17 @@ Both models estimated lower annual salary growth for MHI-affiliated faculty rela
 }{
 \textit{Regression summary CSV not found. Run the SalaryData executable to generate \texttt{analysis\_output/regression\_summary.csv}.}
 }
-\vspace{-10em}
-\begin{figure}[b]
+
+\begin{figure}[h]
     \centering
     \includegraphics[width=.72\textwidth]{figures/scatter.png}
-    \caption{Faculty salaries over time by MHI affiliation, with regression lines showing different growth rates.}
+    \caption{Descriptive salary trajectories by MHI affiliation. Trend lines are illustrative and separate from the fixed-effects, cluster-robust estimates reported in Table~\ref{tab:regression_summary}.}
     \label{fig:scatter_plot}
 \end{figure}
+
+\section{Conclusion}
+
+The updated analysis provides \textit{suggestive} but not definitive evidence of a disparity in salary growth by MHI affiliation. Both pooled and fixed-effects models estimate lower annual growth for MHI-affiliated faculty, but uncertainty intervals include zero in both specifications. On this evidence, the data do not support a strong claim of confirmed systemic bias; they support a cautious conclusion that a potentially meaningful disparity may exist and should be monitored with additional years, richer controls (for example rank/position changes), and robustness checks.
 
 \newpage
 \printbibliography

--- a/main.tex
+++ b/main.tex
@@ -30,6 +30,9 @@ Faculty members were categorized into MHI and non-MHI groups. Salary progression
 \end{enumerate}
 
 Year was centered at the first observed year to improve interpretation and numerical stability. In both models, the key quantity is the coefficient on the year$\times$MHI term, which measures the annual salary-growth difference (MHI minus non-MHI). Cluster-robust standard errors were computed at the faculty level, and 95\% confidence intervals were reported. Model outputs are generated programmatically and written to \texttt{analysis\_output/regression\_summary.csv}.
+\vspace{0.5em}
+
+The primary MHI cohort is defined from the School of Public Health Sciences \href{https://uwaterloo.ca/public-health-sciences/our-people/health-informatics-researchers}{Health informatics researchers page}.
 
 
 \section{Results}


### PR DESCRIPTION
## Summary
- add the SalaryData Xcode project and Swift source files
- keep shared workspace/package files needed for reproducible setup
- add .gitignore entries for LaTeX and Xcode generated artifacts

## Validation
- xcodebuild -list -project SalaryData.xcodeproj
- latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex