### PR TITLE
Fix FP comparison CSV quoting for pgfplotstable

### DIFF
--- a/analysis_output/full_professor_salary_comparison.csv
+++ b/analysis_output/full_professor_salary_comparison.csv
@@ -1,13 +1,13 @@
-Faculty,FP Since,FP Since Source,Salary 2025,Gap from Wallace
-"Wallace, James R.",2025 (Jul 1),User-confirmed,143600.04,0.00
-"Meyer, Samantha",2025 (Jul 1),User-confirmed,185252.60,41652.56
-"Majowicz, Shannon E.",2025 (Jul 1),User-confirmed,185984.68,42384.64
-"Dubin, Joel A.",2021,CV crosswalk,191236.36,47636.32
-"Oremus, Mark",2024,User-confirmed,198800.56,55200.52
-"Hall, Peter A.",2018,CV crosswalk,214268.99,70668.95
-"Cooke, Martin J.",est. pre-2014,Tenure/appointment,222974.48,79374.44
-"McAiney, Carrie",unknown,--,227682.88,84082.84
-"MacEachen, Ellen",unknown,--,231537.87,87937.83
-"Leatherdale, Scott",est. post-2019,Tenure/appointment,248819.80,105219.76
-"Hammond, David",est. post-2012,Tenure/appointment,249279.64,105679.60
-"Hirdes, John",est. pre-2000,Tenure/appointment,267477.92,123877.88
+Faculty,FP Since,Source,Salary 2025,Gap from Wallace
+James R. Wallace,2025 (Jul 1),User-confirmed,143600.04,0.00
+Samantha Meyer,2025 (Jul 1),User-confirmed,185252.60,41652.56
+Shannon E. Majowicz,2025 (Jul 1),User-confirmed,185984.68,42384.64
+Joel A. Dubin,2021,CV crosswalk,191236.36,47636.32
+Mark Oremus,2024,User-confirmed,198800.56,55200.52
+Peter A. Hall,2018,CV crosswalk,214268.99,70668.95
+Martin J. Cooke,est. pre-2014,Tenure/appt.,222974.48,79374.44
+Carrie McAiney,unknown,--,227682.88,84082.84
+Ellen MacEachen,unknown,--,231537.87,87937.83
+Scott Leatherdale,est. post-2019,Tenure/appt.,248819.80,105219.76
+David Hammond,est. post-2012,Tenure/appt.,249279.64,105679.60
+John Hirdes,est. pre-2000,Tenure/appt.,267477.92,123877.88

--- a/main.tex
+++ b/main.tex
@@ -1240,10 +1240,10 @@ Both projections assume linear growth differences over time and hold all other f
     \renewcommand{\arraystretch}{1.15}
     \pgfplotstabletypeset[
         col sep=comma,
-        columns={Faculty,{FP Since},{FP Since Source},{Salary 2025},{Gap from Wallace}},
+        columns={Faculty,{FP Since},Source,{Salary 2025},{Gap from Wallace}},
         columns/Faculty/.style={column name=Faculty, string type, column type=l},
         columns/{FP Since}/.style={column name={Full Prof.\ Since}, string type, column type=c},
-        columns/{FP Since Source}/.style={column name={Source}, string type, column type=l},
+        columns/Source/.style={column name={Source}, string type, column type=l},
         columns/{Salary 2025}/.style={column name={2025 Salary (\$CAD)}, fixed, precision=2, 1000 sep={,}, column type=r},
         columns/{Gap from Wallace}/.style={column name={Gap Above Wallace (\$)}, fixed, precision=2, 1000 sep={,}, column type=r},
         every head row/.style={before row=\toprule, after row=\midrule},


### PR DESCRIPTION
Fixes the `full_professor_salary_comparison.csv` so `pgfplotstable` parses it correctly (removed embedded commas in Faculty names). PDF compiles cleanly.